### PR TITLE
set correct table name, cast connect_id as string

### DIFF
--- a/bq_data_destruction.sql
+++ b/bq_data_destruction.sql
@@ -17,10 +17,10 @@ Approach:
 -----------------------------------------------------------------------------------------------
 -- DDL 1: DELETE ROI Physical Actity Data for Participants that have Requested Data Destruction
 -----------------------------------------------------------------------------------------------
-DELETE FROM ForTestingOnly.roi_physical_activity
+DELETE FROM ROI.physical_activity
 WHERE Connect_ID IN (
-  SELECT Connect_ID
-  FROM FlatConnect.participants_JP
-  WHERE d_831041022 = '353358909'  -- "Destroy Data" flag is "Yes"
-    AND d_861639549 = '353358909'  -- "Data Has Been Destroyed" flag is "Yes"; Ensures DevOps code has run first.
+  SELECT CAST(Connect_ID AS STRING)
+  FROM Connect.participants
+  WHERE d_831041022 = 353358909  -- "Destroy Data" flag is "Yes"
+    AND d_861639549 = 353358909  -- "Data Has Been Destroyed" flag is "Yes"; Ensures DevOps code has run first.
 );


### PR DESCRIPTION
1. set correct table name for table in dev
2. cast Connect_ID in participants table to string prior to comparison with that of ROI.physical_activity table