### PR TITLE
1179 - Initialize bq_data_destruction for ROI.physical_activity

### DIFF
--- a/bq_data_destruction.sql
+++ b/bq_data_destruction.sql
@@ -1,0 +1,25 @@
+/*
+BigQuery Data Destruction Implemented as Scheduled Query
+
+Objective:
+  - Remove derived participant data from BigQuery tables when flagged for destruction.
+  - Ensure that deletions only occur **after the DevOps team has destroyed the data in Firestore**.
+  - This query is scheduled to run once daily.
+
+Approach:
+  - Do not hardcode project to enable CI/CD for dev, stg, prod. BQ will use current project by default.
+  - Extend easily by adding additional DDL statements as needed.
+  - Cannot use CTEs with DELETE statments
+  - Cannot CREATE temporary tables and DROP them within Scheduled Queries
+*/
+
+-----------------------------------------------------------------------------------------------
+-- DDL 1: DELETE ROI Physical Actity Data for Participants that have Requested Data Destruction
+-----------------------------------------------------------------------------------------------
+DELETE FROM ForTestingOnly.roi_physical_activity
+WHERE Connect_ID IN (
+  SELECT Connect_ID
+  FROM FlatConnect.participants_JP
+  WHERE d_831041022 = '353358909'  -- "Destroy Data" flag is "Yes"
+    AND d_861639549 = '353358909'  -- "Data Has Been Destroyed" flag is "Yes"
+);

--- a/bq_data_destruction.sql
+++ b/bq_data_destruction.sql
@@ -7,6 +7,7 @@ Objective:
   - This query is scheduled to run once daily.
 
 Approach:
+  - Maintain code in GitHub; DO NOT edit in directly in UI
   - Do not hardcode project to enable CI/CD for dev, stg, prod. BQ will use current project by default.
   - Extend easily by adding additional DDL statements as needed.
   - Cannot use CTEs with DELETE statments
@@ -21,5 +22,5 @@ WHERE Connect_ID IN (
   SELECT Connect_ID
   FROM FlatConnect.participants_JP
   WHERE d_831041022 = '353358909'  -- "Destroy Data" flag is "Yes"
-    AND d_861639549 = '353358909'  -- "Data Has Been Destroyed" flag is "Yes"
+    AND d_861639549 = '353358909'  -- "Data Has Been Destroyed" flag is "Yes"; Ensures DevOps code has run first.
 );

--- a/bq_data_destruction.sql
+++ b/bq_data_destruction.sql
@@ -17,10 +17,10 @@ Approach:
 -----------------------------------------------------------------------------------------------
 -- DDL 1: DELETE ROI Physical Actity Data for Participants that have Requested Data Destruction
 -----------------------------------------------------------------------------------------------
-DELETE FROM ForTestingOnly.roi_physical_activity
+DELETE FROM ROI.physical_activity
 WHERE Connect_ID IN (
-  SELECT Connect_ID
-  FROM FlatConnect.participants_JP
-  WHERE d_831041022 = '353358909'  -- "Destroy Data" flag is "Yes"
-    AND d_861639549 = '353358909'  -- "Data Has Been Destroyed" flag is "Yes"; Ensures DevOps code has run first.
+  SELECT CAST(Connect_ID AS STRING)
+  FROM Connect.participants
+  WHERE d_831041022 = 353358909  -- "Destroy Data" flag is "Yes"
+    AND d_861639549 = 353358909  -- "Data Has Been Destroyed" flag is "Yes"; Ensures DevOps code has run first.
 );

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
       - "-c"
       - |
         # Set the correct project explicitly
-        gcloud config set --project=${_PROJECT_ID}
+        gcloud config set project ${PROJECT_ID}
         # Now deploy the scheduled query
         bq query \
           --use_legacy_sql=false \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,16 +7,13 @@ steps:
           # Install jq
           apt-get update && apt-get install -y jq
           
-          # Use jq to read the SQL file and create a JSON object for the query parameter.
-          QUERY_PARAMS=$(jq -n --rawfile query bq_data_destruction.sql '{query: $query}')
-          
           # Create the scheduled query transfer configuration.
           bq mk \
             --transfer_config \
             --display_name="bq_data_destruction" \
-            --params="$QUERY_PARAMS" \
+            --params="$(jq -n --rawfile query bq_data_destruction.sql '{query: $query}')" \
             --data_source=scheduled_query \
             --schedule='every day 01:30' \
-            --service_account_name="${SERVICE_ACCOUNT_EMAIL}"
+            --service_account_name="$SERVICE_ACCOUNT_EMAIL"
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,7 +11,6 @@ steps:
           bq update --transfer_config \
             --params="$(jq -n --rawfile query bq_data_destruction.sql '{query: $query}')" \
             --schedule='every day 01:30' \
-            --start_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --location=US \
             --service_account_name="$SERVICE_ACCOUNT_EMAIL" \
             "${_RESOURCE_NAME}"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
           # Update the scheduled query transfer configuration using the pre-defined transfer config ID.
           bq update --transfer_config \
             --params="$(jq -n --rawfile query bq_data_destruction.sql '{query: $query}')" \
-            --schedule='every day 06:30' \
+            --schedule='every day 07:30' \
             --location=US \
             --service_account_name="$SERVICE_ACCOUNT_EMAIL" \
             "${_RESOURCE_NAME}"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,6 +12,6 @@ steps:
           --display_name="bq_data_destruction" \
           --destination_table="" \
           --schedule="cron:30 1 * * *" \
-          --replace < delete_flagged_data.sql
+          --replace < bq_data_destruction.sql
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
       - "-c"
       - |
         # Set the correct project explicitly
-        gcloud config set project ${_PROJECT_ID}
+        gcloud config set --project ${_PROJECT_ID}
         # Now deploy the scheduled query
         bq query \
           --use_legacy_sql=false \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
         bq query \
           --use_legacy_sql=false \
           --display_name="bq_data_destruction" \
-          --schedule='every day 01:30' \
+          --schedule='every day 06:30' \
           --replace < bq_data_destruction.sql
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,8 +11,9 @@ steps:
           bq mk \
             --transfer_config \
             --display_name="bq_data_destruction" \
-            --params="$(jq -n --rawfile query bq_data_destruction.sql '{query: $query, start_time:"2025-02-06T01:30:00Z"}')" \
+            --params="$(jq -n --rawfile query bq_data_destruction.sql '{query: $query}')" \
             --data_source=scheduled_query \
+            --start_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --schedule='every day 01:30' \
             --location=US \
             --service_account_name="$SERVICE_ACCOUNT_EMAIL"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
           # Update the scheduled query transfer configuration using the pre-defined transfer config ID.
           bq update --transfer_config \
             --params="$(jq -n --rawfile query bq_data_destruction.sql '{query: $query}')" \
-            --schedule='every day 01:30' \
+            --schedule='every day 06:30' \
             --location=US \
             --service_account_name="$SERVICE_ACCOUNT_EMAIL" \
             "${_RESOURCE_NAME}"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: "gcr.io/cloud-builders/bq"
+  - name: "gcr.io/cloud-builders/bq:v2.0.93"
     args:
       - query
       - --use_legacy_sql=false

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,10 @@
+steps:
+  - name: "gcr.io/cloud-builders/bq"
+    args:
+      - query
+      - --use_legacy_sql=false
+      - --display_name="bq_data_destruction"
+      - --destination_table=""
+      - --schedule="cron:30 1 * * *"
+      - --replace
+      - < bq_data_destruction.sql

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,8 +10,7 @@ steps:
         bq query \
           --use_legacy_sql=false \
           --display_name="bq_data_destruction" \
-          --destination_table="" \
-          --schedule="cron:30 1 * * *" \
+          --schedule='every day 01:30' \
           --replace < bq_data_destruction.sql
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
           --display_name="bq_data_destruction" \
           --destination_table="" \
           --schedule="cron:30 1 * * *" \
-          --replace < delete_flagged_data.sql
+          --replace < bq_data_destruction.sql
 
 options:
   logging: CLOUD_LOGGING_ONLY  # Ensures logs are stored in Cloud Logging

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,7 +11,7 @@ steps:
           bq mk \
             --transfer_config \
             --display_name="bq_data_destruction" \
-            --params="$(jq -n --rawfile query bq_data_destruction.sql '{query: $query}')" \
+            --params="$(jq -n --rawfile query bq_data_destruction.sql '{query: $query, start_time:"2025-02-06T01:30:00Z"}')" \
             --data_source=scheduled_query \
             --schedule='every day 01:30' \
             --location=US \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,13 +1,15 @@
 steps:
-  - name: "gcr.io/cloud-builders/bq:v2.0.93"
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
+    entrypoint: "bash"
     args:
-      - query
-      - --use_legacy_sql=false
-      - --display_name="bq_data_destruction"
-      - --destination_table=""
-      - --schedule="cron:30 1 * * *"
-      - --replace
-      - < bq_data_destruction.sql
+      - "-c"
+      - |
+        bq query \
+          --use_legacy_sql=false \
+          --display_name="bq_data_destruction" \
+          --destination_table="" \
+          --schedule="cron:30 1 * * *" \
+          --replace < delete_flagged_data.sql
 
 options:
   logging: CLOUD_LOGGING_ONLY  # Ensures logs are stored in Cloud Logging

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,6 +14,7 @@ steps:
             --params="$(jq -n --rawfile query bq_data_destruction.sql '{query: $query}')" \
             --data_source=scheduled_query \
             --schedule='every day 01:30' \
+            --location=US \
             --service_account_name="$SERVICE_ACCOUNT_EMAIL"
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,3 +8,6 @@ steps:
       - --schedule="cron:30 1 * * *"
       - --replace
       - < bq_data_destruction.sql
+
+options:
+  logging: CLOUD_LOGGING_ONLY  # Ensures logs are stored in Cloud Logging

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
       - "-c"
       - |
         # Set the correct project explicitly
-        gcloud config set --project ${_PROJECT_ID}
+        gcloud config set --project=${_PROJECT_ID}
         # Now deploy the scheduled query
         bq query \
           --use_legacy_sql=false \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,12 +8,13 @@ steps:
           apt-get update && apt-get install -y jq
           
           # Update the scheduled query transfer configuration using the pre-defined transfer config ID.
-          bq update --transfer_config "${_RESOURCE_NAME}" \
+          bq update --transfer_config \
             --params="$(jq -n --rawfile query bq_data_destruction.sql '{query: $query}')" \
             --schedule='every day 01:30' \
             --start_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --location=US \
-            --service_account_name="$SERVICE_ACCOUNT_EMAIL"
+            --service_account_name="$SERVICE_ACCOUNT_EMAIL" \
+            "${_RESOURCE_NAME}"
 options:
   logging: CLOUD_LOGGING_ONLY
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,12 +4,14 @@ steps:
     args:
       - "-c"
       - |
+        # Set the correct project explicitly
+        gcloud config set project ${_PROJECT_ID}
+        # Now deploy the scheduled query
         bq query \
           --use_legacy_sql=false \
           --display_name="bq_data_destruction" \
           --destination_table="" \
           --schedule="cron:30 1 * * *" \
-          --replace < bq_data_destruction.sql
-
+          --replace < delete_flagged_data.sql
 options:
-  logging: CLOUD_LOGGING_ONLY  # Ensures logs are stored in Cloud Logging
+  logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,8 +4,11 @@ steps:
     args:
       - "-c"
       - |
-          # Use Python to read the SQL file and create a JSON object.
-          QUERY_PARAMS=$(python -c 'import sys, json; print(json.dumps({"query": sys.stdin.read()}))' < bq_data_destruction.sql)
+          # Install jq
+          apt-get update && apt-get install -y jq
+          
+          # Use jq to read the SQL file and create a JSON object for the query parameter.
+          QUERY_PARAMS=$(jq -n --rawfile query bq_data_destruction.sql '{query: $query}')
           
           # Create the scheduled query transfer configuration.
           bq mk \
@@ -17,4 +20,3 @@ steps:
             --service_account_name="${SERVICE_ACCOUNT_EMAIL}"
 options:
   logging: CLOUD_LOGGING_ONLY
-

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,13 +4,12 @@ steps:
     args:
       - "-c"
       - |
-        # Set the correct project explicitly
-        gcloud config set project ${PROJECT_ID}
-        # Now deploy the scheduled query
-        bq query \
-          --use_legacy_sql=false \
-          --display_name="bq_data_destruction" \
-          --schedule='every day 06:30' \
-          --replace < bq_data_destruction.sql
+          bq mk \
+            --transfer_config \
+            --display_name="bq_data_destruction" \
+            --params="$(jq -n --rawfile query bq_data_destruction.sql '{query: $query}')" \
+            --data_source=scheduled_query \
+            --schedule='every day 01:30' \
+            --service_account_name="${SERVICE_ACCOUNT_EMAIL}"
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,12 +4,16 @@ steps:
     args:
       - "-c"
       - |
+          # Use Python to read the SQL file and generate a JSON object.
+          PARAMS=$(python -c 'import sys, json; print(json.dumps({"query": sys.stdin.read()}))' < bq_data_destruction.sql)
+          
+          # Create the scheduled query transfer configuration.
           bq mk \
             --transfer_config \
             --display_name="bq_data_destruction" \
-            --params="$(jq -n --rawfile query bq_data_destruction.sql '{query: $query}')" \
+            --params="$PARAMS" \
             --data_source=scheduled_query \
             --schedule='every day 01:30' \
-            --service_account_name="${SERVICE_ACCOUNT_EMAIL}"
+            --service_account_name="${_SERVICE_ACCOUNT}"
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,15 +7,13 @@ steps:
           # Install jq
           apt-get update && apt-get install -y jq
           
-          # Create the scheduled query transfer configuration.
-          bq mk \
-            --transfer_config \
-            --display_name="bq_data_destruction" \
+          # Update the scheduled query transfer configuration using the pre-defined transfer config ID.
+          bq update --transfer_config "${_RESOURCE_NAME}" \
             --params="$(jq -n --rawfile query bq_data_destruction.sql '{query: $query}')" \
-            --data_source=scheduled_query \
-            --start_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --schedule='every day 01:30' \
+            --start_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --location=US \
             --service_account_name="$SERVICE_ACCOUNT_EMAIL"
 options:
   logging: CLOUD_LOGGING_ONLY
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,16 +4,17 @@ steps:
     args:
       - "-c"
       - |
-          # Use Python to read the SQL file and generate a JSON object.
-          PARAMS=$(python -c 'import sys, json; print(json.dumps({"query": sys.stdin.read()}))' < bq_data_destruction.sql)
+          # Use Python to read the SQL file and create a JSON object.
+          QUERY_PARAMS=$(python -c 'import sys, json; print(json.dumps({"query": sys.stdin.read()}))' < bq_data_destruction.sql)
           
           # Create the scheduled query transfer configuration.
           bq mk \
             --transfer_config \
             --display_name="bq_data_destruction" \
-            --params="$PARAMS" \
+            --params="$QUERY_PARAMS" \
             --data_source=scheduled_query \
             --schedule='every day 01:30' \
-            --service_account_name="${_SERVICE_ACCOUNT}"
+            --service_account_name="${SERVICE_ACCOUNT_EMAIL}"
 options:
   logging: CLOUD_LOGGING_ONLY
+


### PR DESCRIPTION
https://github.com/episphere/connect/issues/1179
- [bq_data_destruction.sql](https://github.com/Analyticsphere/bq-data-destruction/pull/5/files#diff-95f66b306e1fbf436c0213fdbd67abe9d106a914ccdccba1e17008dda69cc588): Deletes rows in `ROI.physical_activity` table for participants who have requested data destruction.
- [cloudbuild.yaml](https://github.com/Analyticsphere/bq-data-destruction/pull/5/files#diff-0b4a5fc26445836e6672c426692297004cfaba21997343b63e6f58b946bd2a5c): Tells Cloud Build to schedule this query to run at 7:30 UTC, i.e., 2:30AM EST
- This has been tested in dev and stage and is ready for prod.

